### PR TITLE
chore: update GitHub Actions workflows for permissions and versioning

### DIFF
--- a/.github/workflows/nft-resolver-tests.yml
+++ b/.github/workflows/nft-resolver-tests.yml
@@ -5,13 +5,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   nft-resolver-tests:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Cache node modules
         id: cache-npm

--- a/.github/workflows/nft-resolver-tests.yml
+++ b/.github/workflows/nft-resolver-tests.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: write
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/nft-resolver-tests.yml
+++ b/.github/workflows/nft-resolver-tests.yml
@@ -10,10 +10,13 @@ permissions: {}
 jobs:
   nft-resolver-tests:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Cache node modules
         id: cache-npm

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -15,9 +15,11 @@ on:
         required: false
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@1cd598629833fa9fc1694f03abfce8d21b72eb5d # v2.0.6
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@ff5edd492dfd4a70813066fe9f1552a2ac13766f # v2.1.0
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
chore: update GitHub Actions workflows for permissions and versioning

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes with least-privilege permissions and dependency pin updates; no application runtime impact.
> 
> **Overview**
> Hardens GitHub Actions by setting **workflow-level `permissions: {}`** on `nft-resolver-tests` and `security-code-scanner`, so jobs only get the scopes they declare explicitly.
> 
> For **nft-resolver tests**, the job now grants `contents: read` and `actions: write`, bumps `actions/checkout` to **v6.0.3**, and sets **`persist-credentials: false`** on checkout.
> 
> For **security scanning**, the reusable MetaMask scanner workflow is bumped from **v2.0.6** to **v2.1.0**; the job’s `actions`/`contents`/`security-events` permissions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63900b3697db41828cf1ef0dcec46d92f00cdbd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->